### PR TITLE
Fix Post-Level 12 Install Bug

### DIFF
--- a/EpicsAIO/EpicsAIO.csproj
+++ b/EpicsAIO/EpicsAIO.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
     <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SPTarkov.Common" Version="4.0.3" />
-    <PackageReference Include="SPTarkov.DI" Version="4.0.3" />
-    <PackageReference Include="SPTarkov.Server.Core" Version="4.0.3" />
+    <PackageReference Include="SPTarkov.Common" Version="4.0.4" />
+    <PackageReference Include="SPTarkov.DI" Version="4.0.4" />
+    <PackageReference Include="SPTarkov.Server.Core" Version="4.0.4" />
     <PackageReference Include="WTT-ServerCommonLib" Version="2.0.0" />
   </ItemGroup>
 

--- a/EpicsAIO/Utilities/EpicTraderEnforcer.cs
+++ b/EpicsAIO/Utilities/EpicTraderEnforcer.cs
@@ -1,0 +1,23 @@
+﻿using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.DI;
+using SPTarkov.Server.Core.Helpers;
+
+namespace EpicsAIO.Utilities;
+
+[Injectable(TypePriority = OnLoadOrder.PostSptModLoader + 1)]
+public class EpicTraderEnforcer(ProfileHelper profileHelper) : IOnLoad
+{
+    public Task OnLoad()
+    {
+        var profiles = profileHelper.GetProfiles();
+        foreach (var profile in profiles.Select(profilePair => profilePair.Value))
+        {
+            if (profile.CharacterData?.PmcData?.TradersInfo["bd3a8b28356d9c6509966546"] == null) return Task.CompletedTask;
+            if (profile.CharacterData?.PmcData?.Info?.Level >= 12)
+            {
+                profile.CharacterData.PmcData.TradersInfo["bd3a8b28356d9c6509966546"].Unlocked = true;
+            }
+        }
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
If the player is equal to or greater than level 12 prior to installing Badger, the trader will remain locked despite having the prerequisites.

CHANGES:
After SPT has loaded up properly, a post-spt load injectable loops through the player profiles, finds which profiles are greater than level 12, and set the unlock value to true, ensuring eligible players are able to access the trader.