### PR TITLE
LaRue Angled mount modslot adjustments

### DIFF
--- a/EpicsAIO/Resources/db/CustomItems/Misc_Mounts.json
+++ b/EpicsAIO/Resources/db/CustomItems/Misc_Mounts.json
@@ -3878,7 +3878,8 @@
       "mod_scope",
       "mod_scope_000",
       "mod_scope_001",
-      "mod_mount"
+      "mod_mount",
+      "mod_mount_002"
     ],
     "fleaPriceRoubles": 39200,
     "handbookPriceRoubles": 2500,


### PR DESCRIPTION
Added "mod_mount_002" to the LaRue angled mount to allow for use on the SCAR series of rifles.