### PR TITLE
Update EpicsAIO for SPT 4.1.x

### DIFF
--- a/EpicsAIO/EpicMods.cs
+++ b/EpicsAIO/EpicMods.cs
@@ -3,32 +3,33 @@ using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
 using SPTarkov.Server.Core.Models.Spt.Mod;
 using Range = SemanticVersioning.Range;
+using Version = SemanticVersioning.Version;
 
 namespace EpicsAIO;
 
-public record ModMetadata : AbstractModMetadata
+public class ModMetadata : IModMetadata
 {
-    public override string ModGuid { get; init; } = "com.epicrangetime.aio";
-    public override string Name { get; init; } = "Epics All in One";
-    public override string Author { get; init; } = "EpicRangeTime";
-    public override List<string>? Contributors { get; init; } = null;
-    public override SemanticVersioning.Version Version { get; init; } = new(typeof(ModMetadata).Assembly.GetName().Version?.ToString(3));
-    public override Range SptVersion { get; init; } = new("~4.0.13");
-    public override List<string>? Incompatibilities { get; init; }
-    public override Dictionary<string, Range>? ModDependencies { get; init; } = new()
+    public string ModGuid { get; init; } = "com.epicrangetime.aio";
+    public string Name { get; init; } = "Epics All in One";
+    public string Author { get; init; } = "EpicRangeTime";
+    public List<string>? Contributors { get; init; }
+    public Version Version { get; init; } = new(typeof(ModMetadata).Assembly.GetName().Version!.ToString(3));
+    public Range SptVersion { get; init; } = new("~4.1.0");
+    public bool HasPrepatcher { get; init; } = false;
+    public List<string>? Incompatibilities { get; init; }
+    public Dictionary<string, Range>? ModDependencies { get; init; } = new()
     {
-        { "com.wtt.commonlib", new Range("~2.0.20") }
+        { "com.wtt.commonlib", new Range("~3.0.0") }
     };
-    public override string? Url { get; init; }
-    public override bool? IsBundleMod { get; init; } = true;
-    public override string License { get; init; } = "CC-BY-NC-ND 4.0";
+    public string? Url { get; init; } = "https://github.com/EpicRangeTime/EpicRangeTime-Weapons";
+    public string License { get; init; } = "CC-BY-NC-ND 4.0";
 }
 
-[Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 2)]
+[Injectable(TypePriority = OnLoadOrder.PostLoad + 2)]
 public class EpicRangeTimeWeapons(
     WTTServerCommonLib.WTTServerCommonLib wttCommon) : IOnLoad
 {
-    public async Task OnLoad()
+    public async Task OnLoadAsync(CancellationToken cancellationToken)
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
         await wttCommon.CustomItemServiceExtended.CreateCustomItems(assembly);

--- a/EpicsAIO/EpicsAIO.csproj
+++ b/EpicsAIO/EpicsAIO.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>EpicsAIO</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>4.0.8</Version>
+    <Version>4.1.0</Version>
     <!-- The two lines below will set the output path for the binaries -->
     <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SPTarkov.Common" Version="4.0.13" />
-    <PackageReference Include="SPTarkov.DI" Version="4.0.13" />
-    <PackageReference Include="SPTarkov.Server.Core" Version="4.0.13" />
-    <PackageReference Include="WTT-ServerCommonLib" Version="2.0.20" />
+    <PackageReference Include="SPTarkov.Common" Version="4.1.2" />
+    <PackageReference Include="SPTarkov.DI" Version="4.1.2" />
+    <PackageReference Include="SPTarkov.Server.Core" Version="4.1.2" />
+    <PackageReference Include="WTT-ServerCommonLib" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +28,6 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="@echo off&#xA;setlocal enabledelayedexpansion&#xA;&#xA;REM Set variables&#xA;set MODNAME=$(TargetName)&#xA;set DLLPATH=$(TargetDir)$(TargetName).dll&#xA;set OUTDIR=..\..\..\SPT\user\mods\%MODNAME%&#xA;set RESOURCESDIR=$(ProjectDir)Resources&#xA;&#xA;REM Create output directory if it doesn't exist&#xA;if not exist &quot;%OUTDIR%&quot; mkdir &quot;%OUTDIR%&quot;&#xA;&#xA;REM Clear the output directory (except the dll we're about to copy)&#xA;if exist &quot;%OUTDIR%&quot; (&#xA;    for /d %%D in (&quot;%OUTDIR%\*&quot;) do rmdir /s /q &quot;%%D&quot;&#xA;    for %%F in (&quot;%OUTDIR%\*&quot;) do (&#xA;        if /i not &quot;%%~nxF&quot;==&quot;$(TargetName).dll&quot; del /q &quot;%%F&quot;&#xA;    )&#xA;)&#xA;&#xA;REM Copy the DLL file&#xA;copy /Y &quot;%DLLPATH%&quot; &quot;%OUTDIR%\&quot; &gt;nul 2&gt;&amp;1&#xA;echo [PostBuild] Copied %MODNAME%.dll&#xA;&#xA;REM Copy all contents from Resources folder recursively&#xA;if exist &quot;%RESOURCESDIR%&quot; (&#xA;    xcopy &quot;%RESOURCESDIR%&quot; &quot;%OUTDIR%&quot; /E /I /Y &gt;nul 2&gt;&amp;1&#xA;    echo [PostBuild] Copied Resources to output directory&#xA;) else (&#xA;    echo [PostBuild] Warning: Resources folder not found at %RESOURCESDIR%&#xA;)&#xA;&#xA;echo [PostBuild] Build output: %OUTDIR%" />
+    <Exec Command="@echo off&#xA;setlocal enabledelayedexpansion&#xA;&#xA;REM Set variables&#xA;set MODNAME=$(TargetName)&#xA;set DLLPATH=$(TargetDir)$(TargetName).dll&#xA;set OUTDIR=..\..\..\SPT\SPT_Runtime\user\mods\%MODNAME%&#xA;set RESOURCESDIR=$(ProjectDir)Resources&#xA;&#xA;REM Create output directory if it doesn't exist&#xA;if not exist &quot;%OUTDIR%&quot; mkdir &quot;%OUTDIR%&quot;&#xA;&#xA;REM Clear the output directory (except the dll we're about to copy)&#xA;if exist &quot;%OUTDIR%&quot; (&#xA;    for /d %%D in (&quot;%OUTDIR%\*&quot;) do rmdir /s /q &quot;%%D&quot;&#xA;    for %%F in (&quot;%OUTDIR%\*&quot;) do (&#xA;        if /i not &quot;%%~nxF&quot;==&quot;$(TargetName).dll&quot; del /q &quot;%%F&quot;&#xA;    )&#xA;)&#xA;&#xA;REM Copy the DLL file&#xA;copy /Y &quot;%DLLPATH%&quot; &quot;%OUTDIR%\&quot; &gt;nul 2&gt;&amp;1&#xA;echo [PostBuild] Copied %MODNAME%.dll&#xA;&#xA;REM Copy all contents from Resources folder recursively&#xA;if exist &quot;%RESOURCESDIR%&quot; (&#xA;    xcopy &quot;%RESOURCESDIR%&quot; &quot;%OUTDIR%&quot; /E /I /Y &gt;nul 2&gt;&amp;1&#xA;    echo [PostBuild] Copied Resources to output directory&#xA;) else (&#xA;    echo [PostBuild] Warning: Resources folder not found at %RESOURCESDIR%&#xA;)&#xA;&#xA;echo [PostBuild] Build output: %OUTDIR%" />
   </Target>
 </Project>

--- a/EpicsAIO/Resources/bundles.json
+++ b/EpicsAIO/Resources/bundles.json
@@ -3529,13 +3529,6 @@
       ]
     },
     {
-      "key": "mods/stocks/stock_mp5_kurz_pdw.bundle",
-      "dependencyKeys": [
-        "epic_aio_shaders.bundle",
-        "assets/content/items/mods/stocks/stock_mp5k_hk_kurtz_end_cap.bundle"
-      ]
-    },
-    {
       "key": "mods/stocks/str_stock_blk.bundle",
       "dependencyKeys": [
         "shaders"

--- a/EpicsAIO/Traders/Badger.cs
+++ b/EpicsAIO/Traders/Badger.cs
@@ -1,10 +1,9 @@
 ﻿using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
-using SPTarkov.Server.Core.Helpers;
+using SPTarkov.Server.Core.Helpers.Server;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Spt.Config;
 using SPTarkov.Server.Core.Routers;
-using SPTarkov.Server.Core.Servers;
 using SPTarkov.Server.Core.Utils;
 using System.Reflection;
 using Path = System.IO.Path;
@@ -12,21 +11,18 @@ using EpicsAIO.Utilities;
 
 namespace EpicsAIO.Traders;
 
-[Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 1)]
+[Injectable(TypePriority = OnLoadOrder.PostLoad + 1)]
 public class Badger(
     ModHelper modHelper,
     ImageRouter imageRouter,
-    ConfigServer configServer,
     TimeUtil timeUtil,
-    EpicTraderHelper traderHelper
+    EpicTraderHelper traderHelper,
+    TraderConfig traderConfig,
+    RagfairConfig ragfairConfig
 )
     : IOnLoad
 {
-    private readonly TraderConfig _traderConfig = configServer.GetConfig<TraderConfig>();
-    private readonly RagfairConfig _ragfairConfig = configServer.GetConfig<RagfairConfig>();
-
-
-    public Task OnLoad()
+    public Task OnLoadAsync(CancellationToken cancellationToken)
     {
         // A path to the mods files we use below
         var pathToMod = modHelper.GetAbsolutePathToModFolder(Assembly.GetExecutingAssembly());
@@ -39,10 +35,10 @@ public class Badger(
 
         // Create a helper class and use it to register our traders image/icon + set its stock refresh time
         imageRouter.AddRoute(traderBase.Avatar.Replace(".png", ""), traderImagePath);
-        traderHelper.SetTraderUpdateTime(_traderConfig, traderBase, timeUtil.GetHoursAsSeconds(1), timeUtil.GetHoursAsSeconds(2));
+        traderHelper.SetTraderUpdateTime(traderConfig, traderBase, timeUtil.GetHoursAsSeconds(1), timeUtil.GetHoursAsSeconds(2));
 
         // Add our trader to the config file, this lets it be seen by the flea market
-        _ragfairConfig.Traders.TryAdd(traderBase.Id, true);
+        ragfairConfig.Traders.TryAdd(traderBase.Id, true);
 
         // Add our trader (with no items yet) to the server database
         // An 'assort' is the term used to describe the offers a trader sells, it has 3 parts to an assort

--- a/EpicsAIO/Utilities/BaseGameGlobalsEdits.cs
+++ b/EpicsAIO/Utilities/BaseGameGlobalsEdits.cs
@@ -1,17 +1,17 @@
 ﻿using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
 using SPTarkov.Server.Core.Models.Common;
-using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Tables;
 
 namespace EpicsAIO.Utilities;
 
-[Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 4)]
-public class BaseGameGlobalsEdits(DatabaseServer databaseServer) : IOnLoad
+[Injectable(TypePriority = OnLoadOrder.PostLoad + 4)]
+public class BaseGameGlobalsEdits(GlobalTable globalTable) : IOnLoad
 {
-    public Task OnLoad()
+    public Task OnLoadAsync(CancellationToken cancellationToken)
     {
-        var globals = databaseServer.GetTables().Globals;
-        var itemPresets = globals.ItemPresets;
+        var itemPresets = globalTable.ItemPresets;
         if (!itemPresets.TryGetValue(new MongoId("5af08cf886f774223c269184"), out var preset)) return Task.CompletedTask;
         foreach (var item in preset.Items.Where(item => item.SlotId == "mod_sight_rear" && item.Template == ItemTpl.IRONSIGHT_AR15_REAR_SIGHT_CARRY_HANDLE))
         {

--- a/EpicsAIO/Utilities/BaseGameItemEdits.cs
+++ b/EpicsAIO/Utilities/BaseGameItemEdits.cs
@@ -509,7 +509,7 @@ public class BaseGameItemEdits(
                         "5cc125555c98bf150a4fd068"]);
                     break; //Push Wolverine to M60E4 475mm
                 
-                case "6601279cc752a02bbe05e690":
+                case "6601279cc752a02bbe05e692":
                     ModifySlotFilters(item, 0, 0, [
                         "5cc125555c98bf150a4fd068"]);
                     break; //Push Wolverine to M60E3 584mm

--- a/EpicsAIO/Utilities/BaseGameItemEdits.cs
+++ b/EpicsAIO/Utilities/BaseGameItemEdits.cs
@@ -1,21 +1,21 @@
-﻿using SPTarkov.DI.Annotations;
+﻿using SPTarkov.Common.Models.Logging;
+using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
 using SPTarkov.Server.Core.Models.Common;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
-using SPTarkov.Server.Core.Models.Utils;
-using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Models.Spt.Tables;
 using WTTServerCommonLib.Helpers;
 
 namespace EpicsAIO.Utilities;
 
-[Injectable(typePriority: OnLoadOrder.PostDBModLoader + 3)]
+[Injectable(TypePriority = OnLoadOrder.PostLoad + 3)]
 public class BaseGameItemEdits(
     ISptLogger<BaseGameItemEdits> logger,
-    DatabaseService databaseService,
+    TemplateTable templateTable,
     SlotHelper slotHelper
-):IOnLoad
+) : IOnLoad
 {
-    public Task OnLoad()
+    public Task OnLoadAsync(CancellationToken cancellationToken)
     {
         EditFilters();
         return Task.CompletedTask;
@@ -23,7 +23,7 @@ public class BaseGameItemEdits(
 
     private void EditFilters()
     {
-        var dbItems = databaseService.GetItems();
+        var dbItems = templateTable.Items;
         foreach (var (id, item) in dbItems)
         {
             switch (id)
@@ -509,7 +509,7 @@ public class BaseGameItemEdits(
                         "5cc125555c98bf150a4fd068"]);
                     break; //Push Wolverine to M60E4 475mm
                 
-                case "6601279cc752a02bbe05e692":
+                case "6601279cc752a02bbe05e690":
                     ModifySlotFilters(item, 0, 0, [
                         "5cc125555c98bf150a4fd068"]);
                     break; //Push Wolverine to M60E3 584mm

--- a/EpicsAIO/Utilities/EpicTraderHelper.cs
+++ b/EpicsAIO/Utilities/EpicTraderHelper.cs
@@ -1,10 +1,10 @@
-﻿using SPTarkov.DI.Annotations;
+﻿using SPTarkov.Common.Models.Logging;
+using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
 using SPTarkov.Server.Core.Models.Common;
 using SPTarkov.Server.Core.Models.Eft.Common.Tables;
 using SPTarkov.Server.Core.Models.Spt.Config;
-using SPTarkov.Server.Core.Models.Utils;
-using SPTarkov.Server.Core.Services;
+using SPTarkov.Server.Core.Models.Spt.Tables;
 using SPTarkov.Server.Core.Utils.Cloners;
 
 namespace EpicsAIO.Utilities
@@ -12,12 +12,12 @@ namespace EpicsAIO.Utilities
     /// <summary>
     /// We inject this class into 'AddTraderWithDynamicAssorts' to help us with adding the new trader into the server
     /// </summary>
-    [Injectable(TypePriority = OnLoadOrder.PostDBModLoader + 1)]
+    [Injectable(TypePriority = OnLoadOrder.PostLoad + 1)]
     public class EpicTraderHelper(
         ISptLogger<EpicTraderHelper> logger,
         ICloner cloner,
-        DatabaseService databaseService,
-        LocaleService localeService)
+        TradersTable tradersTable,
+        LocaleTable localeTable)
     {
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace EpicsAIO.Utilities
             };
 
             // Add the new trader id and data to the server
-            if (!databaseService.GetTables().Traders.TryAdd(traderDetailsToAdd.Id, traderDataToAdd))
+            if (!tradersTable.TryAdd(traderDetailsToAdd.Id, traderDataToAdd))
             {
                 //Failed to add trader!
             }
@@ -84,7 +84,7 @@ namespace EpicsAIO.Utilities
         public void AddTraderToLocales(TraderBase baseJson, string firstName, string description)
         {
             // For each language, add locale for the new trader
-            var locales = databaseService.GetTables().Locales.Global;
+            var locales = localeTable.Global;
             var newTraderId = baseJson.Id;
             var fullName = baseJson.Name;
             var nickName = baseJson.Nickname;
@@ -113,7 +113,7 @@ namespace EpicsAIO.Utilities
         /// <param name="newAssorts">new assorts we want to add</param>
         public void OverwriteTraderAssort(string traderId, TraderAssort newAssorts)
         {
-            if (!databaseService.GetTables().Traders.TryGetValue(traderId, out var traderToEdit))
+            if (!tradersTable.TryGetValue(traderId, out var traderToEdit))
             {
                 logger.Warning($"Unable to update assorts for trader: {traderId}, they couldn't be found on the server");
 

--- a/EpicsAIO/Utilities/TraderEdits.cs
+++ b/EpicsAIO/Utilities/TraderEdits.cs
@@ -1,16 +1,16 @@
 ﻿using SPTarkov.DI.Annotations;
 using SPTarkov.Server.Core.DI;
-using SPTarkov.Server.Core.Servers;
+using SPTarkov.Server.Core.Models.Enums;
+using SPTarkov.Server.Core.Models.Spt.Tables;
 
 namespace EpicsAIO.Utilities;
 
 [Injectable(TypePriority = OnLoadOrder.TraderRegistration - 1)]
-public class TraderEdits(DatabaseServer databaseServer) : IOnLoad
+public class TraderEdits(TradersTable tradersTable) : IOnLoad
 {
-    public Task OnLoad()
+    public Task OnLoadAsync(CancellationToken cancellationToken)
     {
-        var traders = databaseServer.GetTables().Traders;
-        foreach (var item in traders.Values.Select(trader => trader.Assort).Select(assort => assort.Items).SelectMany(items => items.Where(item => item.Template == ItemTpl.IRONSIGHT_AR15_REAR_SIGHT_CARRY_HANDLE && item.SlotId == "mod_sight_rear")))
+        foreach (var item in tradersTable.Values.Select(trader => trader.Assort).Select(assort => assort.Items).SelectMany(items => items.Where(item => item.Template == ItemTpl.IRONSIGHT_AR15_REAR_SIGHT_CARRY_HANDLE && item.SlotId == "mod_sight_rear")))
         {
             item.SlotId = "mod_scope";
         }


### PR DESCRIPTION
## Summary
- Retarget the mod to **SPT 4.1.x** (`net10.0`, `SPTarkov.*` 4.1.2, `WTT-ServerCommonLib` 3.0.3)
- Migrate SPT 4.1 API changes: `IModMetadata`, `OnLoadAsync`, `OnLoadOrder.PostLoad`, and table-based DI (`TemplateTable`, `TradersTable`, `GlobalTable`, `LocaleTable`, direct config injection)
- Update post-build output path for the SPT 4.1 `SPT_Runtime\user\mods` layout
- Remove a stale `mods/stocks/stock_mp5_kurz_pdw.bundle` entry that pointed at a missing file (correct path under `mods/mp5/` remains)

## Test plan
- [x] `dotnet build -c Release` succeeds against SPT 4.1.2 packages
- [x] Deployed to local SPT 4.1.2 install (`D:\SPT`)
- [x] Server logs show `Epics All in One version: 4.1.0` loaded with WTT 3.0.3 dependency
- [x] Server reached `Server has started, happy playing` with no EpicsAIO exceptions
- [ ] Smoke-test Badger trader + custom items/bundles in-raid on a clean profile if desired
